### PR TITLE
feat: configurable backend base URL for local dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,8 @@ yarn.lock
 node_modules
 react-scratch
 
+# Local env files
+.env*.local
+
 # Generated sitemaps
 public/sitemap*.xml

--- a/src/components/mbs.jsx
+++ b/src/components/mbs.jsx
@@ -63,7 +63,7 @@ export default function MBS({
 						<div
 							className="next-cate-subjects-list"
 							onClick={() => {
-								toggleYearChoose("Mathematics (9231)")
+								toggleYearChoose("Mathematics Further (9231)")
 							}}>
 							<h2>Further Mathematics</h2>
 							<p>

--- a/src/config.jsx
+++ b/src/config.jsx
@@ -1,38 +1,35 @@
+const API_BASE_URL =
+	process.env.NEXT_PUBLIC_API_BASE_URL || "https://node.snapaper.com"
+
+const api = (path) => `${API_BASE_URL}${path}`
+
 export default {
 	apiUrl: {
 		cates: {
-			alevel: "https://node.snapaper.com/api/cates/ppca/as-and-a-level/",
-			igcse: "https://node.snapaper.com/api/cates/ppca/igcse/",
-			// alevel: "https://node.snapaper.com/api/cates/a-levels/",
-			// igcse: "https://node.snapaper.com/api/cates/cambridge-IGCSE/",
-			// alevel: "https://node.snapaper.com/api/cates/ppco/A-Level/",
-			// igcse: "https://node.snapaper.com/api/cates/ppco/IGCSE/",
+			alevel: api("/api/cates/ppca/as-and-a-level/"),
+			igcse: api("/api/cates/ppca/igcse/"),
 		},
 		papers: {
 			xyz: {
-				alevel: "https://node.snapaper.com/api/papers/xyz/A%20Levels/",
-				igcse: "https://node.snapaper.com/api/papers/xyz/IGCSE/",
+				alevel: api("/api/papers/xyz/A%20Levels/"),
+				igcse: api("/api/papers/xyz/IGCSE/"),
 			},
 			com: {
-				alevel: "https://node.snapaper.com/api/papers/com/a-levels/",
-				igcse: "https://node.snapaper.com/api/papers/com/cambridge-IGCSE/",
+				alevel: api("/api/papers/com/a-levels/"),
+				igcse: api("/api/papers/com/cambridge-IGCSE/"),
 			},
 			ppco: {
-				alevel: "https://node.snapaper.com/api/papers/ppco/A-Level/",
-				igcse: "https://node.snapaper.com/api/papers/ppco/IGCSE/",
+				alevel: api("/api/papers/ppco/A-Level/"),
+				igcse: api("/api/papers/ppco/IGCSE/"),
 			},
 			ppca: {
-				alevel: "https://node.snapaper.com/api/papers/ppca/as-and-a-level/",
-				igcse: "https://node.snapaper.com/api/papers/ppca/igcse/",
+				alevel: api("/api/papers/ppca/as-and-a-level/"),
+				igcse: api("/api/papers/ppca/igcse/"),
 			},
 		},
 		years: {
-			alevel: "https://node.snapaper.com/api/years/ppca/as-and-a-level/",
-			igcse: "https://node.snapaper.com/api/years/ppca/igcse/",
-			// alevel: "https://node.snapaper.com/api/years/a-levels/",
-			// igcse: "https://node.snapaper.com/api/years/cambridge-IGCSE/",
-			// alevel: "https://node.snapaper.com/api/years/ppco/A-Level/",
-			// igcse: "https://node.snapaper.com/api/years/ppco/IGCSE/",
+			alevel: api("/api/years/ppca/as-and-a-level/"),
+			igcse: api("/api/years/ppca/igcse/"),
 		},
 	},
 }

--- a/src/utilities/file-download.js
+++ b/src/utilities/file-download.js
@@ -1,5 +1,8 @@
 export const downloadFile = (srcUrl) => {
-	const link = `https://files.snapaper.com/download?filename=${srcUrl}`
+	let link = `https://files.snapaper.com/download?filename=${srcUrl}`
+	if (srcUrl.includes(window.location.hostname)) {
+		link = `${srcUrl}?download=1`
+	}
 	const iframe = document.createElement("iframe")
 	iframe.setAttribute("id", new Date().getTime())
 	iframe.setAttribute("sandbox", "allow-downloads allow-scripts")


### PR DESCRIPTION
## Summary
- Route all API URLs in `src/config.jsx` through `NEXT_PUBLIC_API_BASE_URL`, falling back to `https://node.snapaper.com` so production behavior is unchanged.
- Add `.env*.local` to `.gitignore` for local-only overrides (e.g. `NEXT_PUBLIC_API_BASE_URL=http://localhost:8080`).
- In `file-download.js`, use a same-origin `?download=1` link when the file URL is already on the current host, instead of round-tripping through `files.snapaper.com`.
- Fix the Further Mathematics subject label in `mbs.jsx` (`Mathematics (9231)` → `Mathematics Further (9231)`).

## Test plan
- [ ] `pnpm dev` with `NEXT_PUBLIC_API_BASE_URL=http://localhost:8080` hits the local backend.
- [ ] Production build (no env var) still hits `node.snapaper.com`.
- [ ] Downloads work for both same-origin and `files.snapaper.com` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)